### PR TITLE
README for Centaur

### DIFF
--- a/README
+++ b/README
@@ -1,19 +1,17 @@
 ECL Build Notes
 ~~~~~~~~~~~~~~~
 
-After running git-clone, open a shell in the ecl-iphone-builder
-directory. Alternately, you can download this release as a tar.gz
-archive using the following url:
+Download the release as a tar.gz archive:
 
   curl -L -o ecl-iphone-builder.tar.gz http://github.com/kriyative/ecl-iphone-builder/tarball/centaur
   tar xzf ecl-iphone-builder.tar.gz
+  cd *ecl-iphone-builder-*
 
-The following script assumes the sources were unpacked in the /opt/src
-directory.
+Alternately use git-clone, then open a shell in the ecl-iphone-builder directory.
 
-  cd /opt/src/ecl-iphone-builder
+Next, download ECL:
+
   curl -O http://space.dl.sourceforge.net/project/ecls/ecls/10.4/ecl-10.4.1.tar.gz
-
   tar xzf ecl-10.4.1.tar.gz
 
 [1] Apply the ECL for iOS patches.

--- a/README
+++ b/README
@@ -24,7 +24,7 @@ directory.
 [2] Building ECL for host, simulator, device, and universal
 
   ECL_IOS=/opt/ecl-ios
-  ../build.sh -t all -d ${ECL_IOS} -v 4.2
+  ../build.sh -t all -d ${ECL_IOS} -v 4.3
 
   [Note: if you use a different path for ${ECL_IOS}, then you must
   change the ECL_IOS build var in the eclshell Xcode project]

--- a/README
+++ b/README
@@ -1,13 +1,11 @@
 ECL Build Notes
 ~~~~~~~~~~~~~~~
 
-Download the release as a tar.gz archive:
+Use git-clone, then open a shell in the ecl-iphone-builder directory. Alternatively, download the release as a tar.gz archive:
 
   curl -L -o ecl-iphone-builder.tar.gz http://github.com/kriyative/ecl-iphone-builder/tarball/centaur
   tar xzf ecl-iphone-builder.tar.gz
   cd *ecl-iphone-builder-*
-
-Alternately use git-clone, then open a shell in the ecl-iphone-builder directory.
 
 Next, download ECL:
 

--- a/eclshell/makefile
+++ b/eclshell/makefile
@@ -1,6 +1,6 @@
 # ecl_root -- dir where the host-system's native ECL is installed,
 # including `cmp' module
-sdk_ver = 4.2
+sdk_ver = 4.3
 ecl_root = /opt/ecl-ios
 host_ecl = $(ecl_root)/host
 


### PR DESCRIPTION
I made some changes to the README to 'foolproof' the download instructions for those not using git. Use of wildcards ensures that the directory is correct before downloading ecl no matter the branch:

cd _ecl-iphone-builder-_

I removed the note about assuming that the sources were unpacked in the /opt/src directory as this isn't strictly required.

The changes also includes update to the SDK from 4.2 to 4.3.
