### PR TITLE
README for Centaur

### DIFF
--- a/README
+++ b/README
@@ -57,10 +57,11 @@ Download and setup a SLIME source directory:
 
   cd ../eclshell
   cvs -d :pserver:anonymous:anonymous@common-lisp.net:/project/slime/cvsroot co -D'2010-01-29' slime
+
+The swank-ecl-patches.txt has been submitted to the SLIME maintainers, and hopefully it will make it into 
+the CVS builds one of these days, and this patch step will not be required:
+
   cd slime
-
-The swank-ecl-patches.txt has been submitted to the SLIME maintainers, and hopefully it will make it into the CVS builds one of these days, and this patch step will not be required:
-
   patch -p0 < ../../swank-ecl-patches.txt
   cd ..
 

--- a/README
+++ b/README
@@ -1,19 +1,17 @@
 ECL Build Notes
 ~~~~~~~~~~~~~~~
 
-After running git-clone, open a shell in the ecl-iphone-builder
-directory. Alternately, you can download this release as a tar.gz
-archive using the following url:
+Download the release as a tar.gz archive:
 
   curl -L -o ecl-iphone-builder.tar.gz http://github.com/kriyative/ecl-iphone-builder/tarball/centaur
   tar xzf ecl-iphone-builder.tar.gz
+  cd *ecl-iphone-builder-*
 
-The following script assumes the sources were unpacked in the /opt/src
-directory.
+Alternately use git-clone, then open a shell in the ecl-iphone-builder directory.
 
-  cd /opt/src/ecl-iphone-builder
+Next, download ECL:
+
   curl -O http://space.dl.sourceforge.net/project/ecls/ecls/10.4/ecl-10.4.1.tar.gz
-
   tar xzf ecl-10.4.1.tar.gz
 
 [1] Apply the ECL for iOS patches.

--- a/README
+++ b/README
@@ -53,14 +53,14 @@ which makes it easy to configure the Xcode project.
 eclshell Build Notes
 ~~~~~~~~~~~~~~~~~~~~
 
-Download and setup a SLIME source directory. The swank-ecl-patches.txt
-has been submitted to the SLIME maintainers, and hopefully it will
-make it into the CVS builds one of these days, and the patch step will
-not be required.
+Download and setup a SLIME source directory:
 
   cd ../eclshell
   cvs -d :pserver:anonymous:anonymous@common-lisp.net:/project/slime/cvsroot co -D'2010-01-29' slime
   cd slime
+
+The swank-ecl-patches.txt has been submitted to the SLIME maintainers, and hopefully it will make it into the CVS builds one of these days, and this patch step will not be required:
+
   patch -p0 < ../../swank-ecl-patches.txt
   cd ..
 

--- a/README
+++ b/README
@@ -1,7 +1,8 @@
 ECL Build Notes
 ~~~~~~~~~~~~~~~
 
-Use git-clone, then open a shell in the ecl-iphone-builder directory. Alternatively, download the release as a tar.gz archive:
+Use git-clone, then open a shell in the ecl-iphone-builder directory.
+Alternatively, download the release as a tar.gz archive:
 
   curl -L -o ecl-iphone-builder.tar.gz http://github.com/kriyative/ecl-iphone-builder/tarball/centaur
   tar xzf ecl-iphone-builder.tar.gz

--- a/README
+++ b/README
@@ -24,7 +24,7 @@ directory.
 [2] Building ECL for host, simulator, device, and universal
 
   ECL_IOS=/opt/ecl-ios
-  ../build.sh -t all -d ${ECL_IOS} -v 4.2
+  ../build.sh -t all -d ${ECL_IOS} -v 4.3
 
   [Note: if you use a different path for ${ECL_IOS}, then you must
   change the ECL_IOS build var in the eclshell Xcode project]

--- a/README
+++ b/README
@@ -69,8 +69,12 @@ than the default, be sure to edit the sdk_ver and ecl_root settings in
 
   make			# see makefile for configuring ecl path
 
-That should generate a libeclffi.a fat library. Now open
-eclshell.xcodeproj. If you specified a different path for the ECL
+That should generate a libeclffi.a fat library. Now fire up the project
+in Xcode:
+
+  open -a xcode eclshell.xcodeproj 
+
+If you specified a different path for the ECL
 build than the default (in step 2 above), be sure to change the
 ECL_IOS user defined build setting accordingly.
 

--- a/README
+++ b/README
@@ -1,13 +1,11 @@
 ECL Build Notes
 ~~~~~~~~~~~~~~~
 
-Download the release as a tar.gz archive:
+Use git-clone, then open a shell in the ecl-iphone-builder directory. Alternatively, download the release as a tar.gz archive:
 
   curl -L -o ecl-iphone-builder.tar.gz http://github.com/kriyative/ecl-iphone-builder/tarball/centaur
   tar xzf ecl-iphone-builder.tar.gz
   cd *ecl-iphone-builder-*
-
-Alternately use git-clone, then open a shell in the ecl-iphone-builder directory.
 
 Next, download ECL:
 

--- a/eclshell/MainWindow.xib
+++ b/eclshell/MainWindow.xib
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">768</int>
-		<string key="IBDocument.SystemVersion">10A288</string>
-		<string key="IBDocument.InterfaceBuilderVersion">715</string>
-		<string key="IBDocument.AppKitVersion">1010</string>
-		<string key="IBDocument.HIToolboxVersion">411.00</string>
+		<int key="IBDocument.SystemTarget">1056</int>
+		<string key="IBDocument.SystemVersion">10J869</string>
+		<string key="IBDocument.InterfaceBuilderVersion">1306</string>
+		<string key="IBDocument.AppKitVersion">1038.35</string>
+		<string key="IBDocument.HIToolboxVersion">461.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">46</string>
+			<string key="NS.object.0">301</string>
 		</object>
-		<object class="NSMutableArray" key="IBDocument.EditedObjectIDs">
+		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
-			<integer value="2"/>
+			<string>IBUIWindow</string>
+			<string>IBProxyObject</string>
+			<string>IBUICustomObject</string>
 		</object>
 		<object class="NSArray" key="IBDocument.PluginDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -23,25 +25,29 @@
 			<object class="NSArray" key="dict.sortedKeys" id="0">
 				<bool key="EncodedWithXMLCoder">YES</bool>
 			</object>
-			<object class="NSMutableArray" key="dict.values">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-			</object>
+			<reference key="dict.values" ref="0"/>
 		</object>
 		<object class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
 			<bool key="EncodedWithXMLCoder">YES</bool>
 			<object class="IBProxyObject" id="841351856">
 				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 			</object>
 			<object class="IBProxyObject" id="427554174">
 				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 			</object>
-			<object class="IBUICustomObject" id="664661524"/>
+			<object class="IBUICustomObject" id="664661524">
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
 			<object class="IBUIWindow" id="380026005">
 				<reference key="NSNextResponder"/>
 				<int key="NSvFlags">1316</int>
 				<object class="NSPSMatrix" key="NSFrameMatrix"/>
 				<string key="NSFrameSize">{320, 480}</string>
 				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView"/>
 				<object class="NSColor" key="IBUIBackgroundColor">
 					<int key="NSColorSpace">1</int>
 					<bytes key="NSRGB">MSAxIDEAA</bytes>
@@ -49,6 +55,8 @@
 				<bool key="IBUIOpaque">NO</bool>
 				<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
 				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+				<bool key="IBUIResizesToFullScreen">YES</bool>
 			</object>
 		</object>
 		<object class="IBObjectContainer" key="IBDocument.Objects">
@@ -125,9 +133,7 @@
 					<object class="NSMutableDictionary">
 						<bool key="EncodedWithXMLCoder">YES</bool>
 						<reference key="dict.sortedKeys" ref="0"/>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-						</object>
+						<reference key="dict.values" ref="0"/>
 					</object>
 					<string>{{438, 320}, {320, 480}}</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -138,17 +144,13 @@
 			<object class="NSMutableDictionary" key="unlocalizedProperties">
 				<bool key="EncodedWithXMLCoder">YES</bool>
 				<reference key="dict.sortedKeys" ref="0"/>
-				<object class="NSMutableArray" key="dict.values">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-				</object>
+				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="activeLocalization"/>
 			<object class="NSMutableDictionary" key="localizations">
 				<bool key="EncodedWithXMLCoder">YES</bool>
 				<reference key="dict.sortedKeys" ref="0"/>
-				<object class="NSMutableArray" key="dict.values">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-				</object>
+				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
 			<int key="maxID">9</int>
@@ -163,28 +165,28 @@
 						<string key="NS.key.0">window</string>
 						<string key="NS.object.0">UIWindow</string>
 					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">window</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0">
+							<string key="name">window</string>
+							<string key="candidateClassName">UIWindow</string>
+						</object>
+					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">Classes/eclshellAppDelegate.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">eclshellAppDelegate</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBUserSource</string>
-						<string key="minorKey"/>
+						<string key="minorKey">./Classes/eclshellAppDelegate.h</string>
 					</object>
 				</object>
 			</object>
 		</object>
 		<int key="IBDocument.localizationMode">0</int>
+		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.InterfaceBuilder3</string>
 			<integer value="3100" key="NS.object.0"/>
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<string key="IBDocument.LastKnownRelativeProjectPath">eclshell.xcodeproj</string>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
+		<string key="IBCocoaTouchPluginVersion">301</string>
 	</data>
 </archive>

--- a/eclshell/ecl_boot.c
+++ b/eclshell/ecl_boot.c
@@ -98,7 +98,8 @@ int ecl_boot(const char *root_dir)
     int argc = 1;
     char *argv[256];
     argv[0] = "ecl";
-    GC_register_my_thread(argv);
+    struct GC_stack_base base; 
+    int result = GC_register_my_thread(&base);
     GC_stackbottom = (void*)(argv+255);
     setenv("ECLDIR", "", 1);
     cl_boot(argc, argv);

--- a/eclshell/eclffi.lisp
+++ b/eclshell/eclffi.lisp
@@ -24,7 +24,7 @@
    :set-text
    :set-text-color
    :set-title
-   :set-title-color
+   :set-title-color   :show-simple-alert
    :system-font
    :with-autorelease-pool))
 

--- a/eclshell/eclffi.lisp
+++ b/eclshell/eclffi.lisp
@@ -273,3 +273,20 @@
     (set-text-color view (or text-color (color-argb 1 0 0 0)))
     (when number-of-lines (set-number-of-lines view number-of-lines))
     view))
+
+(defun show-simple-alert (title &key message (dismiss-label "OK"))
+  "Displays a simple alert to notify the user"
+  (check-type title string)
+  (check-type dismiss-label string)
+  (c-fficall (((make-NSString title) :pointer-void)
+              ((make-NSString message) :pointer-void)
+              ((make-NSString dismiss-label) :pointer-void)) :void
+    "{UIAlertView *alert = [[UIAlertView alloc] 
+      initWithTitle: #0
+      message: #1
+      delegate: nil
+      cancelButtonTitle: #2
+      otherButtonTitles: nil];
+     [alert show];
+     [alert release];}"))
+

--- a/eclshell/eclffi.lisp
+++ b/eclshell/eclffi.lisp
@@ -24,7 +24,7 @@
    :set-text
    :set-text-color
    :set-title
-   :set-title-color   :show-simple-alert
+   :set-title-color
    :system-font
    :with-autorelease-pool))
 
@@ -272,21 +272,21 @@
     (set-font view (or font (system-font 24.0)))
     (set-text-color view (or text-color (color-argb 1 0 0 0)))
     (when number-of-lines (set-number-of-lines view number-of-lines))
-    view))
+    view));;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; COCOA(defpackage :cocoa  (:export    :show-alert))
 
-(defun show-simple-alert (title &key message (dismiss-label "OK"))
+(defun cocoa::show-alert (title &key message (dismiss-label "OK"))
   "Displays a simple alert to notify the user"
   (check-type title string)
-  (check-type dismiss-label string)
-  (c-fficall (((make-NSString title) :pointer-void)
-              ((make-NSString message) :pointer-void)
-              ((make-NSString dismiss-label) :pointer-void)) :void
-    "{UIAlertView *alert = [[UIAlertView alloc] 
+  (check-type dismiss-label string)  (flet ((ui-alert-view ()
+           (c-fficall (((make-NSString title) :pointer-void)
+                       ((make-NSString message) :pointer-void)
+                       ((make-NSString dismiss-label) :pointer-void)) :void
+      "{UIAlertView *alert = [[UIAlertView alloc] 
       initWithTitle: #0
       message: #1
       delegate: nil
       cancelButtonTitle: #2
       otherButtonTitles: nil];
      [alert show];
-     [alert release];}"))
+     [alert release];}")))  (mp:process-run-function "alert" #'ui-alert-view)))      
 

--- a/eclshell/eclffi.lisp
+++ b/eclshell/eclffi.lisp
@@ -64,9 +64,12 @@
      [pool release];"))
 
 (defun make-NSString (string)
-  (c-fficall ((string :cstring))
-      :pointer-void
-    "[NSString stringWithCString: #0]" :one-liner t))
+  (if string
+    (c-fficall ((string :cstring))
+       :pointer-void
+      "[NSString stringWithCString: #0]" :one-liner t)
+    (c-fficall () :pointer-void
+     "nil" :one-liner t)))
 
 (defun alloc (class-name &key init)
   (let ((obj (c-fficall ((class-name :cstring))

--- a/eclshell/init.lisp
+++ b/eclshell/init.lisp
@@ -109,7 +109,7 @@ Current time:~25t" (/ internal-time-units-per-second) *gensym-counter*)
      (flet ((notify-user (address port)
               (set-text *label*
                         (format nil "slime: ~a:~a~%"
-                                swank::*loopback-interface* 4005))
+                                address port))
               (eclffi::show-simple-alert "Swank Ready" 
                :message (format nil "Connect to ~a:~a from MCLIDE or Emacs SLIME." 
                                 address port))))

--- a/eclshell/init.lisp
+++ b/eclshell/init.lisp
@@ -110,7 +110,7 @@ Current time:~25t" (/ internal-time-units-per-second) *gensym-counter*)
               (set-text *label*
                         (format nil "slime: ~a:~a~%"
                                 address port))
-              (eclffi::show-simple-alert "Swank Ready" 
+              (eclffi:show-simple-alert "Swank Ready" 
                :message (format nil "Connect to ~a:~a from MCLIDE or Emacs SLIME." 
                                 address port))))
        (cond

--- a/eclshell/init.lisp
+++ b/eclshell/init.lisp
@@ -106,14 +106,19 @@ Current time:~25t" (/ internal-time-units-per-second) *gensym-counter*)
  "SLIME-listener"
  (lambda ()
    (with-autorelease-pool ()
-     (cond
-       ((string-equal (safe-substr (machine-type) 0 2) "iP")
-        (let ((swank::*loopback-interface* (get-ip-address-string)))
-          (swank:create-server :port 4005 :dont-close t)
-          (set-text *label*
-                    (format nil "slime: ~a:~a~%"
-                            swank::*loopback-interface* 4005))))
-       (t
-        (swank:create-server :port 4005 :dont-close t)
-        (set-text *label*
-                  (format nil "slime: ~a:~a~%" "127.0.0.1" 4005)))))))
+     (flet ((notify-user (address port)
+              (set-text *label*
+                        (format nil "slime: ~a:~a~%"
+                                swank::*loopback-interface* 4005))
+              (eclffi::show-simple-alert "Swank Ready" 
+               :message (format nil "Connect to ~a:~a from MCLIDE or Emacs SLIME." 
+                                address port))))
+       (cond
+        ((string-equal (safe-substr (machine-type) 0 2) "iP")
+         (let ((swank::*loopback-interface* (get-ip-address-string)))
+           (swank:create-server :port 4005 :dont-close t)
+           (notify-user swank::*loopback-interface* 4005)))
+        (t
+         (swank:create-server :port 4005 :dont-close t)
+         (notify-user "127.0.0.1" 4005)))))))
+       

--- a/eclshell/init.lisp
+++ b/eclshell/init.lisp
@@ -110,7 +110,7 @@ Current time:~25t" (/ internal-time-units-per-second) *gensym-counter*)
               (set-text *label*
                         (format nil "slime: ~a:~a~%"
                                 address port))
-              (eclffi:show-simple-alert "Swank Ready" 
+              (cocoa::show-alert "Swank Ready" 
                :message (format nil "Connect to ~a:~a from MCLIDE or Emacs SLIME." 
                                 address port))))
        (cond

--- a/eclshell/makefile
+++ b/eclshell/makefile
@@ -1,6 +1,6 @@
 # ecl_root -- dir where the host-system's native ECL is installed,
 # including `cmp' module
-sdk_ver = 4.2
+sdk_ver = 4.3
 ecl_root = /opt/ecl-ios
 host_ecl = $(ecl_root)/host
 


### PR DESCRIPTION
I made some changes to the README to 'foolproof' the download instructions for those not using git. Use of wildcards ensures that the directory is correct before downloading ecl no matter the branch:

cd _ecl-iphone-builder-_

I removed the note about assuming that the sources were unpacked in the /opt/src directory as this isn't strictly required.

The changes also includes update to the SDK from 4.2 to 4.3.
